### PR TITLE
Switch to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+dist: bionic
+
+install:
+  - pip install -r requirements.txt flake8
+
+script:
+  - flake8 .

--- a/OmeroFenton.py
+++ b/OmeroFenton.py
@@ -18,17 +18,6 @@ import taillog
 import aggregator
 import signal
 import threading
-import imp
-
-
-# Python versions before 3.0 do not use UTF-8 encoding
-# by default. To ensure that Unicode is handled properly
-# throughout set the default encoding to UTF-8.
-if sys.version_info < (3, 0):
-    imp.reload(sys)
-    sys.setdefaultencoding('utf8')
-else:
-    raw_input = input
 
 
 logtype_map = {
@@ -144,7 +133,7 @@ class OmeroFenton(object):
         logging.debug(body)
         reply = None
         repunc = re.escape(string.punctuation)
-        pattern = '(^|[%s\s])@?%s([%s\s]|$)' % (repunc, self.botname, repunc)
+        pattern = r'(^|[%s\s])@?%s([%s\s]|$)' % (repunc, self.botname, repunc)
         if re.search(pattern, body, re.IGNORECASE):
             reply = 'OMERO Adverse Reporting of System Errors\n\n'
             reply += 'Monitoring started: %s\n' % self.started
@@ -271,7 +260,7 @@ def main():
 
     postconfig = []
 
-    for logtype in list(logcfgs.keys()):
+    for logtype in logcfgs.keys():
         for cfg in logcfgs[logtype]:
             if logtype == 'diskmonitor':
                 add_disk_reporter(logtype, bot, cfg)

--- a/OmeroFenton.py
+++ b/OmeroFenton.py
@@ -5,7 +5,7 @@ import sys
 import logging
 import ast
 import json
-import Queue
+import queue
 import re
 import string
 from slackclient import SlackClient
@@ -18,13 +18,14 @@ import taillog
 import aggregator
 import signal
 import threading
+import imp
 
 
 # Python versions before 3.0 do not use UTF-8 encoding
 # by default. To ensure that Unicode is handled properly
 # throughout set the default encoding to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
+    imp.reload(sys)
     sys.setdefaultencoding('utf8')
 else:
     raw_input = input
@@ -53,7 +54,7 @@ class OmeroFenton(object):
         self.started = time.strftime('%Y-%m-%d %H:%M:%S %Z')
         self.reporters = []
         self.aggregators = []
-        self._log_output = Queue.Queue()
+        self._log_output = queue.Queue()
 
         self.slack_client = SlackClient(token)
         self.slack_call('api.test')
@@ -136,7 +137,7 @@ class OmeroFenton(object):
             self.slack_call(
                 'chat.postMessage', channel=self.channel,
                 username=self.botname, attachments=log)
-        except Queue.Empty:
+        except queue.Empty:
             pass
 
     def status(self, body):
@@ -270,7 +271,7 @@ def main():
 
     postconfig = []
 
-    for logtype in logcfgs.keys():
+    for logtype in list(logcfgs.keys()):
         for cfg in logcfgs[logtype]:
             if logtype == 'diskmonitor':
                 add_disk_reporter(logtype, bot, cfg)

--- a/aggregator.py
+++ b/aggregator.py
@@ -1,5 +1,5 @@
 import logging
-import Queue
+import queue
 import re
 import smtplib
 import time
@@ -22,7 +22,7 @@ class AggregateAlerter(object):
         self.delay = delay
         self.interval = interval
 
-        self.queue = Queue.Queue()
+        self.queue = queue.Queue()
         self.alerters = []
         self.last_event = None
         self.new_events = False
@@ -59,7 +59,7 @@ class AggregateAlerter(object):
         try:
             while True:
                 msgs.append(self.queue.get(block=False))
-        except Queue.Empty:
+        except queue.Empty:
             pass
         self.new_events = False
         return msgs
@@ -123,7 +123,7 @@ class EmailAlerter(object):
         self.send(email)
 
     def send(self, email):
-        for a in xrange(self.max_attempts):
+        for a in range(self.max_attempts):
             try:
                 s = smtplib.SMTP(self.smtp)
                 logging.debug('Sending email to %s', self.toaddrs)

--- a/configurator.py
+++ b/configurator.py
@@ -3,7 +3,7 @@
 
 import logging
 import argparse
-import ConfigParser
+import configparser
 
 
 maincfgname = 'main'
@@ -32,7 +32,7 @@ def configure():
 
     args = parser.parse_args()
 
-    config = ConfigParser.SafeConfigParser()
+    config = configparser.SafeConfigParser()
     config.optionxform = str
     if not config.read(args.config):
         raise Exception('Invalid configuration file: %s' % args.config)

--- a/diskmonitor.py
+++ b/diskmonitor.py
@@ -31,14 +31,14 @@ class DiskMonitor(object):
         free_mb, total_mb = self.get_disk_space()
 
         newstate = self.state
-        for n in xrange(len(self.warnlevels) - 1, -1, -1):
+        for n in range(len(self.warnlevels) - 1, -1, -1):
             wl = self.warnlevels[n]
             if free_mb <= wl:
                 logging.debug('free_mb <= warn[%d] (%d)', n, wl)
                 newstate = max(newstate, n + 1)
                 break
 
-        for n in xrange(0, len(self.warnlevels)):
+        for n in range(0, len(self.warnlevels)):
             wl = self.warnlevels[n] + self.hysteresis
             if free_mb > wl:
                 logging.debug('free_mb > warn[%d] + hysteresis (%d)', n, wl)

--- a/pytail.py
+++ b/pytail.py
@@ -42,7 +42,7 @@ class PyTail(object):
                         try:
                             ispipe = stat.S_ISFIFO(
                                 os.fstat(f.fileno()).st_mode)
-                        except:
+                        except Exception:
                             ispipe = False
                         if not ispipe:
                             raise
@@ -92,13 +92,13 @@ class LogParser(object):
         self.next_match = None
 
     def parse(self):
-        self.current = self.__next__
+        self.current = self.next
         self.next = None
 
         for line in self.tail:
             if self.got_line(line):
                 self.message_cb(self.current, self.current_match)
-                self.current = self.__next__
+                self.current = self.next
                 self.current_match = self.next_match
                 self.next = None
 

--- a/pytail.py
+++ b/pytail.py
@@ -72,7 +72,7 @@ class PyTail(object):
 
 
 def default_message_cb(msg, match):
-    print 'MESSAGE: %s' % msg
+    print('MESSAGE: %s' % msg)
 
 
 def default_log_start_f(line):
@@ -92,13 +92,13 @@ class LogParser(object):
         self.next_match = None
 
     def parse(self):
-        self.current = self.next
+        self.current = self.__next__
         self.next = None
 
         for line in self.tail:
             if self.got_line(line):
                 self.message_cb(self.current, self.current_match)
-                self.current = self.next
+                self.current = self.__next__
                 self.current_match = self.next_match
                 self.next = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-slackclient
+# Version 2 contains breaking changes
+# https://github.com/slackapi/python-slackclient/wiki/Migrating-to-2.x
+slackclient>=1.3.2,<2

--- a/taillog.py
+++ b/taillog.py
@@ -14,9 +14,9 @@ class LogReporter(object):
 
         self.sinks = []
 
-        self.log_re = re.compile('^(?P<date>\d\d\d\d-\d\d-\d\d) '
-                                 '(?P<time>\d\d:\d\d:\d\d,\d\d\d) '
-                                 '(?P<level>\w+) ')
+        self.log_re = re.compile(r'^(?P<date>\d\d\d\d-\d\d-\d\d) '
+                                 r'(?P<time>\d\d:\d\d:\d\d,\d\d\d) '
+                                 r'(?P<level>\w+) ')
         self.max_log_length = 1024
         self.counts = dict.fromkeys(self.levels, 0)
 
@@ -139,7 +139,7 @@ class LimitLogAllReporter(LimitLogReporter):
         self.level_wildcard = '*'
         self.counts[self.level_wildcard] = 0
         # Override the log start regexp, logs all levels
-        self.log_re = re.compile('^\S')
+        self.log_re = re.compile(r'^\S')
         logging.debug('log_re:%s', self.log_re.pattern)
 
     def log_received(self, msg, match):
@@ -156,8 +156,8 @@ class LimitLogDateLevelReporter(LimitLogReporter):
     def __init__(self, file, name, rep, levels, limitn, limitt):
         super(LimitLogDateLevelReporter, self).__init__(
             file, name, rep, levels, limitn, limitt)
-        self.log_re = re.compile('^(?P<date>[A-Z][a-z][a-z] \d\d, \d\d\d\d) '
-                                 '(?P<time>\d?\d:\d\d:\d\d [A-Z][A-Z]) ')
+        self.log_re = re.compile(r'^(?P<date>[A-Z][a-z][a-z] \d\d, \d\d\d\d) '
+                                 r'(?P<time>\d?\d:\d\d:\d\d [A-Z][A-Z]) ')
         self.loglevel_re = re.compile('^(?P<level>[A-Z]+): ')
 
     def log_received(self, msg, match):
@@ -166,7 +166,7 @@ class LimitLogDateLevelReporter(LimitLogReporter):
         try:
             lm = self.loglevel_re.match(msg.splitlines()[1])
             level = lm.groupdict()['level']
-        except:
+        except Exception:
             level = None
         if level in self.levels:
             self.counts[level] += 1

--- a/taillog.py
+++ b/taillog.py
@@ -69,7 +69,7 @@ class LogReporter(object):
     def status(self):
         m = '%s:    %s' % (
             self.name, '  '.join(
-                '%s: %d' % c for c in self.counts.iteritems()))
+                '%s: %d' % c for c in self.counts.items()))
         logging.debug('status: %s', m)
         return m
 


### PR DESCRIPTION
`2to3 -w -n .` plus some other fixes. This is needed for https://github.com/ome/ansible-role-omero-logmonitor/pull/4

Tested by manually running a second bot on test81 with the same config file (only the bot-name was changed):
![Screen Shot 2020-03-09 at 16 15 32](https://user-images.githubusercontent.com/1644105/76234473-b0549f00-6221-11ea-8090-842143703474.png)

First message is the slack notification from the current bot, second message is from the python 3 one